### PR TITLE
ENH: Add itkPolyDataToMeshFilter

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,151 @@
+## This config file is only relevant for clang-format version 8.0.0
+##
+## Examples of each format style can be found on the in the clang-format documentation
+## See: https://clang.llvm.org/docs/ClangFormatStyleOptions.html for details of each option
+##
+## The clang-format binaries can be downloaded as part of the clang binary distributions
+## from http://releases.llvm.org/download.html
+##
+## Use the script Utilities/Maintenance/clang-format.bash to faciliate
+## maintaining a consistent code style.
+##
+## EXAMPLE apply code style enforcement before commit:
+#     Utilities/Maintenance/clang-format.bash --clang ${PATH_TO_CLANG_FORMAT_8.0.0} --modified
+## EXAMPLE apply code style enforcement after commit:
+#     Utilities/Maintenance/clang-format.bash --clang ${PATH_TO_CLANG_FORMAT_8.0.0} --last
+---
+# This configuration requires clang-format version 8.0.0 exactly.
+BasedOnStyle: Mozilla
+Language:        Cpp
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: true
+AlignEscapedNewlines: Right
+AlignOperands:   true
+AlignTrailingComments: true
+# clang 9.0 AllowAllArgumentsOnNextLine: true
+# clang 9.0 AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+# clang 9.0 AllowShortLambdasOnASingleLine: All
+# clang 9.0 features AllowShortIfStatementsOnASingleLine: Never
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: All
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: false
+BinPackParameters: false
+BreakBeforeBraces: Custom
+BraceWrapping:
+  # clang 9.0 feature AfterCaseLabel:  false
+  AfterClass:      true
+  AfterControlStatement: true
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: true
+  AfterStruct:     true
+  AfterUnion:      true
+  AfterExternBlock: true
+  BeforeCatch:     true
+  BeforeElse:      true
+## This is the big change from historical ITK formatting!
+# Historically ITK used a style similar to https://en.wikipedia.org/wiki/Indentation_style#Whitesmiths_style
+# with indented braces, and not indented code.  This style is very difficult to automatically
+# maintain with code beautification tools.  Not indenting braces is more common among
+# formatting tools.
+  IndentBraces:    false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakBeforeBinaryOperators: None
+#clang 6.0 BreakBeforeInheritanceComma: true
+BreakInheritanceList: BeforeComma
+BreakBeforeTernaryOperators: true
+#clang 6.0 BreakConstructorInitializersBeforeComma: true
+BreakConstructorInitializers: BeforeComma
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+## The following line allows larger lines in non-documentation code
+ColumnLimit:     120
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 2
+Cpp11BracedListStyle: false
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainRegex: '(Test)?$'
+IndentCaseLabels: true
+IndentPPDirectives: AfterHash
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+## The following line allows larger lines in non-documentation code
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Middle
+ReflowComments:  true
+# We may want to sort the includes as a separate pass
+SortIncludes:    false
+# We may want to revisit this later
+SortUsingDeclarations: false
+SpaceAfterCStyleCast: false
+# SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        2
+UseTab:          Never
+...

--- a/examples/itkPolyDataToMeshFilter.ipynb
+++ b/examples/itkPolyDataToMeshFilter.ipynb
@@ -1,0 +1,510 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# itkPolyDataToMeshFilter\n",
+    "\n",
+    "This example serves to demonstrate use of `itkMeshToPolyDataFilter` and `itkPolyDataToMeshFilter` for conversion between `itk.Mesh` and `itk.PolyData` data structures. An `itk.Mesh` object stores geometric data as a collection of `CellInterface` objects defined on the IDs of an underlying `itk.PointSet`, while an `itk.PolyData` object stores geometric data as a collection of points and a list of point IDs segmented by cell. `itk.Mesh` supports standard mesh formats and is useful for I/O with `itk.meshread` and `itk.meshwrite`, while `itk.PolyData` is often useful for visualization with `vtk`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from urllib.request import urlretrieve\n",
+    "\n",
+    "import itk\n",
+    "from itkwidgets import view"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Get Mesh Input"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MESH_FILE = 'Input/cow.vtk'\n",
+    "\n",
+    "# Download mesh\n",
+    "os.makedirs('Input', exist_ok=True)\n",
+    "if not os.path.exists(MESH_FILE):\n",
+    "    url = 'https://data.kitware.com/api/v1/file/5c43feba8d777f072b0cd3da/download'\n",
+    "    urlretrieve(url, MESH_FILE)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mesh_input = itk.meshread(MESH_FILE, itk.D)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2903\n",
+      "3263\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(mesh_input.GetNumberOfPoints())\n",
+    "print(mesh_input.GetNumberOfCells())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "itkPointF3 ([3.71636, 2.34339, 0])\n",
+      "itkPointF3 ([4.12656, 0.642027, 0])\n",
+      "itkPointF3 ([3.45497, 2.16988, 0])\n",
+      "itkPointF3 ([3.92925, 0.411689, 0])\n",
+      "itkPointF3 ([3.24741, 2.07333, 0])\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Visualize points\n",
+    "for i in range(0,5):\n",
+    "    print(mesh_input.GetPoints().GetElement(i))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9a86a686b49a44bb982404601090aa47",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Viewer(geometries=[{'vtkClass': 'vtkPolyData', 'points': {'vtkClass': 'vtkPoints', 'numberOfComponents': 3, 'd…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "view(geometries=[mesh_input])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Test preservation of point data\n",
+    "mesh_input.GetPointData().Reserve(1)\n",
+    "mesh_input.GetPointData().SetElement(0,500) #FIXME remove"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Convert to `itk.PolyData`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filter = itk.MeshToPolyDataFilter[type(mesh_input)].New(Input=mesh_input)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filter.Update()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "poly_data = filter.GetOutput()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert(type(poly_data) == itk.PolyData[itk.D])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[250, 251, 210, 252]\n",
+      "[252, 210, 201, 253]\n",
+      "[253, 201, 254]\n",
+      "[254, 255, 256, 253]\n",
+      "[253, 256, 257, 252]\n",
+      "[252, 257, 258, 250]\n",
+      "[258, 257, 259, 260]\n",
+      "[260, 259, 261, 262]\n",
+      "[262, 261, 263]\n",
+      "[263, 261, 264, 265]\n",
+      "[265, 264, 266]\n",
+      "[266, 264, 267]\n",
+      "[267, 264, 268, 269]\n",
+      "[268, 264, 261, 259]\n",
+      "[259, 257, 256, 268]\n",
+      "[268, 256, 255, 269]\n",
+      "[255, 254, 270]\n",
+      "[269, 271, 272]\n",
+      "[272, 267, 269]\n",
+      "[272, 273, 274, 267]\n",
+      "[273, 272, 271]\n",
+      "[267, 274, 275]\n",
+      "[267, 275, 276, 266]\n",
+      "[266, 276, 277, 265]\n",
+      "[265, 277, 278]\n",
+      "[265, 278, 279, 263]\n",
+      "[263, 279, 280, 262]\n",
+      "[271, 281, 282, 273]\n",
+      "[273, 282, 283, 274]\n",
+      "[274, 283, 284, 275]\n",
+      "[284, 285, 276]\n",
+      "[276, 285, 286, 277]\n",
+      "[277, 286, 287, 278]\n",
+      "[278, 287, 288, 279]\n",
+      "[279, 288, 289, 280]\n",
+      "[281, 15, 16, 282]\n",
+      "[282, 16, 17, 283]\n",
+      "[283, 17, 18, 284]\n",
+      "[284, 18, 19, 285]\n",
+      "[285, 19, 20, 286]\n",
+      "[286, 20, 21, 287]\n",
+      "[287, 21, 22, 288]\n",
+      "[288, 22, 23, 289]\n",
+      "[290, 190, 291]\n",
+      "[291, 177, 290]\n",
+      "[290, 177, 292]\n",
+      "[292, 293, 290]\n",
+      "[290, 293, 191]\n",
+      "[254, 201, 192]\n",
+      "[192, 201, 200]\n",
+      "[200, 191, 192]\n",
+      "[254, 293, 292, 270]\n",
+      "[270, 292, 271]\n",
+      "[271, 292, 294]\n",
+      "[294, 295, 281, 271]\n",
+      "[281, 295, 24, 15]\n",
+      "[24, 295, 179, 11]\n",
+      "[271, 269, 255]\n",
+      "[270, 271, 255]\n",
+      "[192, 191, 293]\n",
+      "[254, 192, 293]\n",
+      "[177, 178, 294, 292]\n",
+      "[294, 178, 179, 295]\n",
+      "[444, 547, 459]\n",
+      "[547, 444, 548]\n",
+      "[548, 444, 428]\n",
+      "[549, 459, 550]\n",
+      "[550, 459, 547, 551]\n",
+      "[551, 547, 548, 552]\n",
+      "[552, 548, 428, 553]\n",
+      "[553, 428, 554]\n",
+      "[554, 428, 555]\n",
+      "[556, 549, 550, 557]\n",
+      "[557, 550, 551, 558]\n",
+      "[558, 551, 552, 559]\n",
+      "[559, 552, 560, 561]\n",
+      "[560, 552, 553]\n",
+      "[560, 553, 554, 562]\n",
+      "[562, 554, 555, 563]\n",
+      "[563, 555, 564]\n",
+      "[564, 565, 563]\n",
+      "[563, 565, 562]\n",
+      "[562, 565, 561, 560]\n",
+      "[564, 555, 410, 411]\n",
+      "[411, 410, 566, 567]\n",
+      "[567, 566, 392]\n",
+      "[392, 568, 569, 567]\n",
+      "[567, 569, 411]\n",
+      "[569, 568, 570, 571]\n",
+      "[568, 392, 393]\n",
+      "[393, 392, 572]\n",
+      "[572, 392, 373, 573]\n",
+      "[573, 373, 374]\n",
+      "[374, 373, 574]\n",
+      "[574, 373, 354, 355]\n",
+      "[574, 355, 356, 375]\n",
+      "[375, 374, 574]\n",
+      "[374, 375, 573]\n",
+      "[573, 375, 394, 572]\n",
+      "[570, 568, 393]\n",
+      "[571, 570, 394, 575]\n",
+      "[575, 576, 571]\n",
+      "[571, 411, 569]\n",
+      "[411, 571, 577]\n",
+      "[577, 578, 411]\n",
+      "[411, 578, 564]\n",
+      "[564, 578, 579]\n",
+      "[579, 578, 580]\n",
+      "[580, 578, 577, 581]\n",
+      "[579, 580, 582]\n",
+      "[582, 580, 581, 412]\n",
+      "[412, 581, 576]\n",
+      "[412, 576, 583]\n",
+      "[583, 394, 375, 376]\n",
+      "[376, 375, 356, 357]\n",
+      "[357, 356, 337, 338]\n",
+      "[338, 29, 31, 357]\n",
+      "[357, 31, 33, 376]\n",
+      "[376, 33, 35, 583]\n",
+      "[583, 35, 37, 412]\n",
+      "[412, 37, 45, 582]\n",
+      "[582, 45, 46, 584]\n",
+      "[584, 585, 579, 582]\n",
+      "[579, 585, 561]\n",
+      "[561, 565, 579]\n",
+      "[579, 565, 564]\n",
+      "[586, 556, 557, 587]\n",
+      "[587, 557, 558, 588]\n",
+      "[588, 558, 559, 589]\n",
+      "[589, 559, 561, 585]\n",
+      "[585, 584, 590, 591]\n",
+      "[591, 592, 589, 585]\n",
+      "[589, 592, 593, 588]\n",
+      "[588, 593, 594, 595]\n",
+      "[595, 596, 597, 588]\n",
+      "[588, 597, 598, 587]\n",
+      "[587, 598, 599, 586]\n",
+      "[586, 599, 600, 601]\n",
+      "[603, 602, 604, 47]\n",
+      "[47, 604, 605, 48]\n",
+      "[48, 605, 606, 49]\n",
+      "[49, 606, 596, 595]\n",
+      "[595, 594, 607, 49]\n",
+      "[49, 607, 608, 50]\n",
+      "[50, 608, 609, 46]\n",
+      "[46, 609, 590, 584]\n",
+      "[570, 393, 394]\n",
+      "[572, 394, 393]\n",
+      "[611, 610, 612, 613]\n",
+      "[613, 612, 614, 615]\n",
+      "[615, 614, 616, 617]\n",
+      "[617, 616, 618, 619]\n",
+      "[619, 618, 620, 621]\n",
+      "[621, 620, 622, 623]\n",
+      "[623, 622, 624, 625]\n",
+      "[625, 624, 626, 627]\n",
+      "[627, 626, 628, 629]\n",
+      "[629, 628, 630]\n",
+      "[630, 628, 51, 52]\n",
+      "[51, 628, 626, 53]\n",
+      "[54, 624, 622, 55]\n",
+      "[55, 622, 620, 56]\n",
+      "[56, 620, 618, 57]\n",
+      "[57, 618, 616, 58]\n",
+      "[58, 616, 614, 59]\n",
+      "[59, 614, 612, 60]\n",
+      "[60, 612, 610, 61]\n",
+      "[61, 610, 603, 47]\n",
+      "[53, 626, 624, 54]\n",
+      "[629, 631, 627]\n",
+      "[627, 631, 632, 625]\n",
+      "[625, 632, 633, 623]\n",
+      "[623, 633, 634, 621]\n",
+      "[621, 634, 635, 619]\n",
+      "[619, 635, 636, 617]\n",
+      "[617, 636, 615]\n",
+      "[637, 546, 638]\n",
+      "[631, 637, 632]\n",
+      "[632, 637, 638, 633]\n",
+      "[633, 638, 639, 634]\n",
+      "[634, 639, 640, 635]\n",
+      "[635, 640, 636]\n",
+      "[640, 639, 641]\n",
+      "[630, 52, 62, 642]\n",
+      "[642, 62, 63, 643]\n",
+      "[641, 639, 638, 546]\n",
+      "[734, 705, 699, 735]\n",
+      "[732, 688, 736, 737]\n",
+      "[737, 736, 676, 738]\n",
+      "[734, 735, 739]\n",
+      "[739, 740, 741]\n",
+      "[741, 740, 742]\n",
+      "[744, 745, 746, 747]\n",
+      "[747, 746, 748, 749]\n",
+      "[749, 748, 750, 751]\n",
+      "[751, 752, 753, 749]\n",
+      "[749, 753, 754, 747]\n",
+      "[747, 754, 755, 744]\n",
+      "[756, 748, 746, 757]\n",
+      "[757, 746, 745, 758]\n",
+      "[758, 759, 760, 761]\n",
+      "[762, 755, 754, 763]\n",
+      "[764, 763, 754, 753]\n",
+      "[753, 752, 764]\n",
+      "[765, 758, 745]\n",
+      "[737, 738, 760, 759]\n",
+      "[732, 743, 721, 688]\n",
+      "[735, 699, 721, 743]\n",
+      "[766, 739, 741, 767]\n",
+      "[767, 741, 742, 768]\n",
+      "[768, 742, 762, 769]\n",
+      "[770, 764, 752, 771]\n",
+      "[769, 762, 763, 772]\n",
+      "[772, 763, 764, 770]\n",
+      "[773, 767, 768, 774]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Visualize cells as collections of point IDs\n",
+    "\n",
+    "i = 0\n",
+    "polygons = poly_data.GetPolygons()\n",
+    "while i < 1000:\n",
+    "    x = list()\n",
+    "    for j in range(0,polygons.ElementAt(i)):\n",
+    "        x.append(polygons.ElementAt(i + 1 + j))\n",
+    "    print(x)\n",
+    "    i += polygons.ElementAt(i) + 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Convert back to `itk.Mesh`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filter = itk.PolyDataToMeshFilter[type(poly_data)].New(Input=poly_data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filter.Update()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mesh_output = filter.GetOutput()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "assert(mesh_output.GetNumberOfPoints() == mesh_input.GetNumberOfPoints())\n",
+    "assert(mesh_output.GetNumberOfCells() == mesh_input.GetNumberOfCells())\n",
+    "for i in range(0,mesh_output.GetNumberOfPoints()):\n",
+    "    assert(mesh_output.GetPoint(i) == mesh_input.GetPoint(i))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "de7f8f07558e443392b3dbd6859b2ef0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Viewer(geometries=[{'vtkClass': 'vtkPolyData', 'points': {'vtkClass': 'vtkPoints', 'numberOfComponents': 3, 'd…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "view(geometries=[mesh_output])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "venv-itk4",
+   "language": "python",
+   "name": "venv-itk4"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/include/itkPolyDataToMeshFilter.h
+++ b/include/itkPolyDataToMeshFilter.h
@@ -1,0 +1,118 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkPolyDataToMeshFilter_h
+#define itkPolyDataToMeshFilter_h
+
+#include "itkProcessObject.h"
+#include "itkPolyData.h"
+#include "itkMesh.h"
+
+#include <type_traits>
+
+namespace itk
+{
+/** \class PolyDataToMeshFilter
+ *
+ * \brief Convert PolyData to a Mesh
+ *
+ * Convert an itk::PolyData to an itk::PointSet or itk::Mesh
+ *
+ * \ingroup MeshToPolyData
+ *
+ */
+template <typename TInputPolyData>
+class PolyDataToMeshFilter : public ProcessObject
+{
+public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(PolyDataToMeshFilter);
+
+  /** Standard class typedefs. */
+  using Self = PolyDataToMeshFilter<TInputPolyData>;
+  using Superclass = ProcessObject;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
+
+  /** Standard New macro. */
+  itkNewMacro(Self);
+
+  /** Run-time type information. */
+  itkTypeMacro(PolyDataToMeshFilter, ProcessObject);
+
+  static constexpr unsigned int PointDimension = TInputPolyData::PointDimension;
+
+  using InputPolyDataType = TInputPolyData;
+  using PolyDataType = InputPolyDataType;
+  using OutputMeshType = Mesh<typename InputPolyDataType::PixelType, PointDimension>;
+  using MeshType = OutputMeshType;
+
+  using OutputCoordRepType = typename OutputMeshType::CoordRepType;
+  using OutputPointPixelType = typename OutputMeshType::PixelType;
+  using OutputCellPixelType = typename OutputMeshType::CellPixelType;
+  using OutputPointType = typename OutputMeshType::PointType;
+  using OutputPointIdentifier = typename OutputMeshType::PointIdentifier;
+  using OutputCellIdentifier = typename OutputMeshType::CellIdentifier;
+  using OutputCellAutoPointer = typename OutputMeshType::CellAutoPointer;
+  using OutputCellType = typename OutputMeshType::CellType;
+
+  /** Set the polydata input of this process object.  */
+  using Superclass::SetInput;
+  void
+  SetInput(const InputPolyDataType * input);
+
+  /** Get the polydata input of this process object.  */
+  const InputPolyDataType *
+  GetInput() const;
+
+  const InputPolyDataType *
+  GetInput(unsigned int idx) const;
+
+  OutputMeshType *
+  GetOutput();
+  const OutputMeshType *
+  GetOutput() const;
+
+  OutputMeshType *
+  GetOutput(unsigned int idx);
+
+  void
+  GenerateOutputInformation() override;
+
+protected:
+  PolyDataToMeshFilter();
+  ~PolyDataToMeshFilter() override = default;
+
+  void
+  PrintSelf(std::ostream & os, Indent indent) const override;
+
+  void
+  GenerateData() override;
+
+  ProcessObject::DataObjectPointer
+  MakeOutput(ProcessObject::DataObjectPointerArraySizeType idx) override;
+  ProcessObject::DataObjectPointer
+  MakeOutput(const ProcessObject::DataObjectIdentifierType &) override;
+
+private:
+};
+} // namespace itk
+
+#ifndef ITK_MANUAL_INSTANTIATION
+#  include "itkPolyDataToMeshFilter.hxx"
+#endif
+
+#endif // itkPolyDataToMeshFilter

--- a/include/itkPolyDataToMeshFilter.hxx
+++ b/include/itkPolyDataToMeshFilter.hxx
@@ -1,0 +1,358 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkPolyDataToMeshFilter_hxx
+#define itkPolyDataToMeshFilter_hxx
+
+#include "itkPolyDataToMeshFilter.h"
+
+#include "itkVertexCell.h"
+#include "itkLineCell.h"
+#include "itkMesh.h"
+#include "itkTriangleCell.h"
+#include "itkQuadrilateralCell.h"
+#include "itkPolygonCell.h"
+
+namespace itk
+{
+
+template <typename TInputPolyData>
+PolyDataToMeshFilter<TInputPolyData>::PolyDataToMeshFilter()
+{
+  // Modify superclass default values, can be overridden by subclasses
+  this->SetNumberOfRequiredInputs(1);
+
+  typename MeshType::Pointer output = static_cast<MeshType *>(this->MakeOutput(0).GetPointer());
+  this->ProcessObject::SetNumberOfRequiredOutputs(1);
+  this->ProcessObject::SetNthOutput(0, output.GetPointer());
+}
+
+
+template <typename TInputPolyData>
+void
+PolyDataToMeshFilter<TInputPolyData>::PrintSelf(std::ostream & os, Indent indent) const
+{
+  Superclass::PrintSelf(os, indent);
+}
+
+
+template <typename TInputPolyData>
+void
+PolyDataToMeshFilter<TInputPolyData>::SetInput(const TInputPolyData * input)
+{
+  // Process object is not const-correct so the const_cast is required here
+  this->ProcessObject::SetNthInput(0, const_cast<TInputPolyData *>(input));
+}
+
+
+template <typename TInputPolyData>
+const typename PolyDataToMeshFilter<TInputPolyData>::InputPolyDataType *
+PolyDataToMeshFilter<TInputPolyData>::GetInput() const
+{
+  return itkDynamicCastInDebugMode<const TInputPolyData *>(this->GetPrimaryInput());
+}
+
+
+template <typename TInputPolyData>
+const typename PolyDataToMeshFilter<TInputPolyData>::InputPolyDataType *
+PolyDataToMeshFilter<TInputPolyData>::GetInput(unsigned int idx) const
+{
+  return dynamic_cast<const InputPolyDataType *>(this->ProcessObject::GetInput(idx));
+}
+
+
+template <typename TInputPolyData>
+ProcessObject::DataObjectPointer PolyDataToMeshFilter<TInputPolyData>::MakeOutput(
+  ProcessObject::DataObjectPointerArraySizeType)
+{
+  return MeshType::New().GetPointer();
+}
+
+
+template <typename TInputPolyData>
+ProcessObject::DataObjectPointer
+PolyDataToMeshFilter<TInputPolyData>::MakeOutput(const ProcessObject::DataObjectIdentifierType &)
+{
+  return MeshType::New().GetPointer();
+}
+
+
+template <typename TInputPolyData>
+typename PolyDataToMeshFilter<TInputPolyData>::MeshType *
+PolyDataToMeshFilter<TInputPolyData>::GetOutput()
+{
+  // we assume that the first output is of the templated type
+  return itkDynamicCastInDebugMode<MeshType *>(this->GetPrimaryOutput());
+}
+
+
+template <typename TInputPolyData>
+const typename PolyDataToMeshFilter<TInputPolyData>::MeshType *
+PolyDataToMeshFilter<TInputPolyData>::GetOutput() const
+{
+  // we assume that the first output is of the templated type
+  return itkDynamicCastInDebugMode<const MeshType *>(this->GetPrimaryOutput());
+}
+
+
+template <typename TInputPolyData>
+typename PolyDataToMeshFilter<TInputPolyData>::MeshType *
+PolyDataToMeshFilter<TInputPolyData>::GetOutput(unsigned int idx)
+{
+  auto * out = dynamic_cast<MeshType *>(this->ProcessObject::GetOutput(idx));
+
+  if (out == nullptr && this->ProcessObject::GetOutput(idx) != nullptr)
+  {
+    itkWarningMacro(<< "Unable to convert output number " << idx << " to type " << typeid(MeshType).name());
+  }
+  return out;
+}
+
+template <typename TInputPolyData>
+void
+PolyDataToMeshFilter<TInputPolyData>::GenerateOutputInformation()
+{
+  // Polydata does not contain sufficient metadata to inform a PointSet or Mesh object
+  // so do nothing and leave default point set metadata values
+
+  // m_MaximumNumberOfRegions = 1;
+  // m_NumberOfRegions = 1;
+  // m_BufferedRegion = -1;
+  // m_RequestedNumberOfRegions = 0;
+  // m_RequestedRegion = -1;
+}
+
+template <typename TInputPolyData>
+void
+PolyDataToMeshFilter<TInputPolyData>::GenerateData()
+{
+  const InputPolyDataType * inputPolyData = this->GetInput();
+  MeshType *                outputMesh = this->GetOutput();
+
+  // Set points in output mesh
+  using PolyDataPointsContainerType = typename InputPolyDataType::PointsContainer;
+  using MeshPointsContainerType = typename OutputMeshType::PointsContainer;
+  const PolyDataPointsContainerType *       inputPoints = inputPolyData->GetPoints();
+  typename MeshPointsContainerType::Pointer outputPoints = MeshPointsContainerType::New();
+  outputPoints->resize(inputPoints->Size());
+
+  typename PolyDataPointsContainerType::ConstIterator inputPointItr = inputPoints->Begin();
+  typename PolyDataPointsContainerType::ConstIterator inputPointEnd = inputPoints->End();
+
+  typename MeshPointsContainerType::Iterator outputPointItr = outputPoints->Begin();
+  while (inputPointItr != inputPointEnd)
+  {
+    for (unsigned int ii = 0; ii < InputPolyDataType::PointDimension; ++ii)
+    {
+      outputPointItr.Value()[ii] = inputPointItr.Value()[ii];
+    }
+    ++inputPointItr;
+    ++outputPointItr;
+  }
+  outputMesh->SetPoints(outputPoints);
+
+  // Set point data in output mesh
+  using PointDataContainerType = typename InputPolyDataType::PointDataContainer;
+  const PointDataContainerType * inputPointData = inputPolyData->GetPointData();
+  if (inputPointData)
+  {
+    typename PointDataContainerType::Pointer outputPointData = PointDataContainerType::New();
+    outputPointData->Reserve(inputPointData->Size());
+
+    typename PointDataContainerType::ConstIterator inputPointDataItr = inputPointData->Begin();
+    typename PointDataContainerType::ConstIterator inputPointDataEnd = inputPointData->End();
+
+    typename PointDataContainerType::Iterator outputPointDataItr = outputPointData->Begin();
+
+    while (inputPointDataItr != inputPointDataEnd)
+    {
+      outputPointDataItr.Value() = inputPointDataItr.Value();
+      ++inputPointDataItr;
+      ++outputPointDataItr;
+    }
+    outputMesh->SetPointData(outputPointData);
+  }
+
+  // Set different cell types
+  using CellContainerType = typename InputPolyDataType::CellsContainer;
+  using CellType = typename OutputMeshType::CellType;
+  typename CellContainerType::ConstIterator inputCellItr;
+  typename CellContainerType::ConstIterator inputCellEnd;
+
+  IdentifierType numPoints = 0, cellId = 0;
+
+  // Set vertex cells
+  using VertexCellType = itk::VertexCell<CellType>;
+  const CellContainerType * inputVertices = inputPolyData->GetVertices();
+  inputCellItr = inputVertices->Begin();
+  inputCellEnd = inputVertices->End();
+
+  while (inputCellItr != inputCellEnd)
+  {
+    auto numPoints = inputCellItr.Value();
+    ++inputCellItr;
+
+    // Verify vertex contains exactly one point ID
+    itkAssertInDebugAndIgnoreInReleaseMacro(numPoints == VertexCellType::NumberOfPoints);
+
+    // Create cell
+    typename CellType::CellAutoPointer cell;
+    cell.TakeOwnership(new VertexCellType);
+
+    cell->SetPointId(0, inputCellItr.Value());
+    ++inputCellItr;
+
+    outputMesh->SetCell(cellId, cell);
+    cellId++;
+  }
+
+  // Set line cells
+  using LineCellType = itk::LineCell<CellType>;
+  const CellContainerType * inputLines = inputPolyData->GetLines();
+  inputCellItr = inputLines->Begin();
+  inputCellEnd = inputLines->End();
+
+  while (inputCellItr != inputCellEnd)
+  {
+    auto numPoints = inputCellItr.Value();
+    ++inputCellItr;
+
+    // Verify lines contain exactly two point IDs
+    itkAssertInDebugAndIgnoreInReleaseMacro(numPoints == LineCellType::NumberOfPoints);
+
+    // Create cell
+    typename CellType::CellAutoPointer cell;
+    cell.TakeOwnership(new LineCellType);
+
+    for (unsigned int i = 0; i < numPoints; i++)
+    {
+      cell->SetPointId(i, inputCellItr.Value());
+      ++inputCellItr;
+    }
+
+    outputMesh->SetCell(cellId, cell);
+    cellId++;
+  }
+
+  // Set triangle cells from strips
+  using TriangleCellType = itk::TriangleCell<CellType>;
+  const CellContainerType * inputStrips = inputPolyData->GetTriangleStrips();
+  inputCellItr = inputStrips->Begin();
+  inputCellEnd = inputStrips->End();
+
+  while (inputCellItr != inputCellEnd)
+  {
+    auto numPoints = inputCellItr.Value();
+    ++inputCellItr;
+
+    // Verify at least one strip is described
+    itkAssertInDebugAndIgnoreInReleaseMacro(numPoints >= TriangleCellType::NumberOfPoints);
+
+    // Create cell
+    typename CellContainerType::ConstIterator stripCellEnd = inputCellItr;
+
+    for (unsigned int i = 0; i < numPoints - 2; i++)
+    {
+      typename CellType::CellAutoPointer cell;
+      cell.TakeOwnership(new TriangleCellType);
+
+      cell->SetPointId(0, inputCellItr.Value());
+      inputCellItr++;
+      cell->SetPointId(1, inputCellItr.Value());
+      inputCellItr++;
+      cell->SetPointId(2, inputCellItr.Value());
+      inputCellItr--;
+
+      outputMesh->SetCell(cellId, cell);
+      cellId++;
+    }
+    inputCellItr += 2;
+  }
+
+  // Set polygons
+  const CellContainerType * inputPolygons = inputPolyData->GetPolygons();
+
+  inputCellItr = inputPolygons->Begin();
+  inputCellEnd = inputPolygons->End();
+
+  using QuadrilateralCellType = itk::QuadrilateralCell<CellType>;
+  using PolygonCellType = itk::PolygonCell<CellType>;
+
+  // Polygons are stored in a 1D list as [# points] [p1] [p2] ... [# points] [p1] [p2] ... etc
+  while (inputCellItr != inputCellEnd)
+  {
+    auto numPoints = inputCellItr.Value();
+    ++inputCellItr;
+
+    typename CellType::CellAutoPointer cell;
+    if (numPoints == VertexCellType::NumberOfPoints)
+    {
+      cell.TakeOwnership(new VertexCellType);
+    }
+    else if (numPoints == LineCellType::NumberOfPoints)
+    {
+      cell.TakeOwnership(new LineCellType);
+    }
+    else if (numPoints == TriangleCellType::NumberOfPoints)
+    {
+      cell.TakeOwnership(new TriangleCellType);
+    }
+    else if (numPoints == QuadrilateralCellType::NumberOfPoints)
+    {
+      cell.TakeOwnership(new QuadrilateralCellType);
+    }
+    else
+    {
+      cell.TakeOwnership(new PolygonCellType(numPoints));
+    }
+
+    for (unsigned int i = 0; i < numPoints; i++)
+    {
+      cell->SetPointId(i, inputCellItr.Value());
+      ++inputCellItr;
+    }
+
+    outputMesh->SetCell(cellId, cell);
+    cellId++;
+  }
+
+  // Set cell data in output mesh
+  using CellDataContainerType = typename InputPolyDataType::CellDataContainer;
+  const CellDataContainerType * inputCellData = inputPolyData->GetCellData();
+  if (inputCellData)
+  {
+    typename CellDataContainerType::Pointer outputCellData = CellDataContainerType::New();
+    outputCellData->Reserve(inputCellData->Size());
+
+    typename CellDataContainerType::ConstIterator inputCellDataItr = inputCellData->Begin();
+    typename CellDataContainerType::ConstIterator inputCellDataEnd = inputCellData->End();
+
+    typename CellDataContainerType::Iterator outputCellDataItr = outputCellData->Begin();
+
+    while (inputCellDataItr != inputCellDataEnd)
+    {
+      outputCellDataItr.Value() = inputCellDataItr.Value();
+      ++inputCellDataItr;
+      ++outputCellDataItr;
+    }
+    outputMesh->SetCellData(outputCellData);
+  }
+}
+
+} // end namespace itk
+
+#endif // itkPolyDataToMeshFilter_hxx

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,6 +4,7 @@ set(MeshToPolyDataTests
   itkImageToPointSetFilterTest.cxx
   itkMeshToPolyDataFilterTest.cxx
   itkPolyDataTest.cxx
+  itkPolyDataToMeshFilterTest.cxx
   )
 
 CreateTestDriver(MeshToPolyData "${MeshToPolyData-Test_LIBRARIES}" "${MeshToPolyDataTests}")
@@ -26,3 +27,7 @@ itk_add_test(NAME itkImageToPointSetFilterTest
     DATA{Input/foot.mha}
     ${ITK_TEST_OUTPUT_DIR}/itkImageToPointSetFilterTestOutput.vtk
   )
+
+itk_add_test(NAME itkPolyDataToMeshFilterTest
+    COMMAND MeshToPolyDataTestDriver
+    itkPolyDataToMeshFilterTest)

--- a/test/itkPolyDataToMeshFilterTest.cxx
+++ b/test/itkPolyDataToMeshFilterTest.cxx
@@ -1,0 +1,173 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#include "itkMesh.h"
+#include "itkPolyData.h"
+#include "itkPolyDataToMeshFilter.h"
+
+#include "itkTestingMacros.h"
+
+template <typename TPixelType>
+void
+MakePolyDataSample(itk::PolyData<TPixelType> *);
+
+int
+itkPolyDataToMeshFilterTest(int, char *[])
+{
+
+  using PixelType = double;
+
+  using PolyDataType = itk::PolyData<PixelType>;
+  PolyDataType::Pointer polyData = PolyDataType::New();
+
+  MakePolyDataSample<PixelType>(polyData);
+
+  using FilterType = itk::PolyDataToMeshFilter<PolyDataType>;
+  FilterType::Pointer filter = FilterType::New();
+
+  filter->SetInput(polyData);
+
+  ITK_TRY_EXPECT_NO_EXCEPTION(filter->Update());
+
+  constexpr unsigned int PointDimension = PolyDataType::PointDimension;
+  using MeshType = FilterType::OutputMeshType;
+  MeshType::Pointer meshResult = filter->GetOutput();
+
+  ITK_TEST_EXPECT_EQUAL(meshResult->GetNumberOfPoints(), polyData->GetNumberOfPoints());
+  ITK_TEST_EXPECT_EQUAL(meshResult->GetPoint(0)[0], 1);
+  ITK_TEST_EXPECT_EQUAL(meshResult->GetPoint(0)[1], 3);
+  ITK_TEST_EXPECT_EQUAL(meshResult->GetPoint(0)[2], 5);
+  ITK_TEST_EXPECT_EQUAL(meshResult->GetPoint(1)[0], 4);
+  ITK_TEST_EXPECT_EQUAL(meshResult->GetPoint(1)[1], 6);
+  ITK_TEST_EXPECT_EQUAL(meshResult->GetPoint(1)[2], 8);
+  ITK_TEST_EXPECT_EQUAL(meshResult->GetPoint(2)[0], 3);
+  ITK_TEST_EXPECT_EQUAL(meshResult->GetPoint(2)[1], 5);
+  ITK_TEST_EXPECT_EQUAL(meshResult->GetPoint(2)[2], 7);
+
+  ITK_TEST_EXPECT_EQUAL(meshResult->GetNumberOfCells(), 7);
+
+  // Verify vertex cells
+  typename MeshType::CellAutoPointer cellPtr;
+  meshResult->GetCell(0, cellPtr);
+  ITK_TEST_EXPECT_EQUAL(cellPtr->GetNumberOfPoints(), 1);
+  ITK_TEST_EXPECT_EQUAL(cellPtr->GetPointIdsContainer()[0], 4);
+  meshResult->GetCell(1, cellPtr);
+  ITK_TEST_EXPECT_EQUAL(cellPtr->GetNumberOfPoints(), 1);
+  ITK_TEST_EXPECT_EQUAL(cellPtr->GetPointIdsContainer()[0], 7);
+
+  // Verify line cells
+  meshResult->GetCell(2, cellPtr);
+  ITK_TEST_EXPECT_EQUAL(cellPtr->GetNumberOfPoints(), 2);
+  ITK_TEST_EXPECT_EQUAL(cellPtr->GetPointIdsContainer()[0], 4);
+  ITK_TEST_EXPECT_EQUAL(cellPtr->GetPointIdsContainer()[1], 5);
+  meshResult->GetCell(3, cellPtr);
+  ITK_TEST_EXPECT_EQUAL(cellPtr->GetNumberOfPoints(), 2);
+  ITK_TEST_EXPECT_EQUAL(cellPtr->GetPointIdsContainer()[0], 7);
+  ITK_TEST_EXPECT_EQUAL(cellPtr->GetPointIdsContainer()[1], 8);
+
+  // Verify triangle strips (now cells
+  meshResult->GetCell(4, cellPtr);
+  ITK_TEST_EXPECT_EQUAL(cellPtr->GetNumberOfPoints(), 3);
+  ITK_TEST_EXPECT_EQUAL(cellPtr->GetPointIdsContainer()[0], 0);
+  ITK_TEST_EXPECT_EQUAL(cellPtr->GetPointIdsContainer()[1], 2);
+  ITK_TEST_EXPECT_EQUAL(cellPtr->GetPointIdsContainer()[2], 1);
+  meshResult->GetCell(5, cellPtr);
+  ITK_TEST_EXPECT_EQUAL(cellPtr->GetNumberOfPoints(), 3);
+  ITK_TEST_EXPECT_EQUAL(cellPtr->GetPointIdsContainer()[0], 2);
+  ITK_TEST_EXPECT_EQUAL(cellPtr->GetPointIdsContainer()[1], 1);
+  ITK_TEST_EXPECT_EQUAL(cellPtr->GetPointIdsContainer()[2], 3);
+
+
+  // Verify triangle cells
+  meshResult->GetCell(6, cellPtr);
+  ITK_TEST_EXPECT_EQUAL(cellPtr->GetNumberOfPoints(), 3);
+  ITK_TEST_EXPECT_EQUAL(cellPtr->GetPointIdsContainer()[0], 0);
+  ITK_TEST_EXPECT_EQUAL(cellPtr->GetPointIdsContainer()[1], 1);
+  ITK_TEST_EXPECT_EQUAL(cellPtr->GetPointIdsContainer()[2], 2);
+
+  return EXIT_SUCCESS;
+}
+
+// From itkPolyDataTest.cxx
+template <typename TPixelType>
+void
+MakePolyDataSample(itk::PolyData<TPixelType> * polyData)
+{
+  using PixelType = TPixelType;
+  using PolyDataType = itk::PolyData<TPixelType>;
+
+  constexpr unsigned int PointDimension = PolyDataType::PointDimension;
+
+  polyData->Initialize();
+
+  using PointsContainerType = typename PolyDataType::PointsContainer;
+  typename PointsContainerType::Pointer pointsContainer = PointsContainerType::New();
+
+  typename PolyDataType::PointType point;
+  point[0] = 1.0;
+  point[1] = 3.0;
+  point[2] = 5.0;
+  pointsContainer->InsertElement(0, point);
+  point[0] = 2.0;
+  point[1] = 4.0;
+  point[2] = 6.0;
+  pointsContainer->InsertElement(1, point);
+  point[0] = 3.0;
+  point[1] = 5.0;
+  point[2] = 7.0;
+  pointsContainer->InsertElement(2, point);
+  polyData->SetPoints(pointsContainer);
+
+  point[0] = 4.0;
+  point[1] = 6.0;
+  point[2] = 8.0;
+  polyData->SetPoint(1, point);
+
+  using CellContainerType = typename PolyDataType::CellsContainer;
+  typename CellContainerType::Pointer vertices = CellContainerType::New();
+  vertices->InsertElement(0, 1);
+  vertices->InsertElement(1, 4);
+  vertices->InsertElement(2, 1);
+  vertices->InsertElement(3, 7);
+  polyData->SetVertices(vertices);
+
+  typename CellContainerType::Pointer lines = CellContainerType::New();
+  lines->InsertElement(0, 2);
+  lines->InsertElement(1, 4);
+  lines->InsertElement(2, 5);
+  lines->InsertElement(3, 2);
+  lines->InsertElement(4, 7);
+  lines->InsertElement(5, 8);
+  polyData->SetLines(lines);
+
+  typename CellContainerType::Pointer strips = CellContainerType::New();
+  strips->InsertElement(0, 4);
+  strips->InsertElement(1, 0);
+  strips->InsertElement(2, 2);
+  strips->InsertElement(3, 1);
+  strips->InsertElement(4, 3);
+  polyData->SetTriangleStrips(strips);
+
+  typename CellContainerType::Pointer polygons = CellContainerType::New();
+  polygons->InsertElement(0, 3);
+  polygons->InsertElement(1, 0);
+  polygons->InsertElement(2, 1);
+  polygons->InsertElement(3, 2);
+  polyData->SetPolygons(polygons);
+
+  return;
+}

--- a/wrapping/itkPolyDataToMeshFilter.wrap
+++ b/wrapping/itkPolyDataToMeshFilter.wrap
@@ -1,0 +1,9 @@
+itk_wrap_include("itkPolyData.h")
+itk_wrap_include("itkDefaultStaticMeshTraits.h")
+
+itk_wrap_class("itk::PolyDataToMeshFilter" POINTER)
+  UNIQUE(types "${WRAP_ITK_SCALAR};D")
+    foreach(t ${types})
+      itk_wrap_template("PD${ITKM_${t}}" "itk::PolyData< ${ITKT_${t}} >")
+  endforeach()
+itk_end_wrap_class()


### PR DESCRIPTION
Adds `itk::PolyDataToMeshFilter` with testing and Jupyter Notebook example.