### PR TITLE
ENH: Adding changes for itk::PolyLineCell

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -17,14 +17,17 @@ jobs:
           - os: ubuntu-18.04
             c-compiler: "gcc"
             cxx-compiler: "g++"
+            itk-git-tag: "v5.3rc04"
             cmake-build-type: "MinSizeRel"
           - os: windows-2019
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
+            itk-git-tag: "v5.3rc04"
             cmake-build-type: "Release"
           - os: macos-10.15
             c-compiler: "clang"
             cxx-compiler: "clang++"
+            itk-git-tag: "v5.3rc04"
             cmake-build-type: "MinSizeRel"
 
     steps:
@@ -135,7 +138,13 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
+<<<<<<< HEAD
         python-version: [37, 38, 39, 310]
+=======
+        python-version: [36, 37, 38, 39]
+        include:
+          - itk-python-git-tag: "46dd4156e3adfa7cda8952cbec786fbd063ebc79"
+>>>>>>> f70eb6d (ENH: Adding Python test for itk::PolyLineCell conversion)
 
     steps:
     - uses: actions/checkout@v2
@@ -171,7 +180,11 @@ jobs:
       max-parallel: 2
       matrix:
         include:
+<<<<<<< HEAD
           - itk-python-git-tag: "v5.3rc04"
+=======
+          - itk-python-git-tag: "46dd4156e3adfa7cda8952cbec786fbd063ebc79"
+>>>>>>> f70eb6d (ENH: Adding Python test for itk::PolyLineCell conversion)
 
     steps:
     - uses: actions/checkout@v2
@@ -207,7 +220,11 @@ jobs:
       matrix:
         python-version-minor: [7, 8, 9, 10]
         include:
+<<<<<<< HEAD
           - itk-python-git-tag: "v5.3rc04"
+=======
+          - itk-python-git-tag: "46dd4156e3adfa7cda8952cbec786fbd063ebc79"
+>>>>>>> f70eb6d (ENH: Adding Python test for itk::PolyLineCell conversion)
 
     steps:
     - name: Get specific version of CMake, Ninja

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -3,7 +3,7 @@ name: Build, test, package
 on: [push,pull_request]
 
 env:
-  itk-git-tag: "835dc01388d22c4b4c9a46b01dbdfe394ec23511"
+  itk-git-tag: "v5.3rc04"
   itk-wheel-tag: "v5.3rc04.post2"
 
 jobs:

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -138,13 +138,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-<<<<<<< HEAD
         python-version: [37, 38, 39, 310]
-=======
-        python-version: [36, 37, 38, 39]
-        include:
-          - itk-python-git-tag: "46dd4156e3adfa7cda8952cbec786fbd063ebc79"
->>>>>>> f70eb6d (ENH: Adding Python test for itk::PolyLineCell conversion)
 
     steps:
     - uses: actions/checkout@v2
@@ -178,13 +172,6 @@ jobs:
     runs-on: macos-10.15
     strategy:
       max-parallel: 2
-      matrix:
-        include:
-<<<<<<< HEAD
-          - itk-python-git-tag: "v5.3rc04"
-=======
-          - itk-python-git-tag: "46dd4156e3adfa7cda8952cbec786fbd063ebc79"
->>>>>>> f70eb6d (ENH: Adding Python test for itk::PolyLineCell conversion)
 
     steps:
     - uses: actions/checkout@v2
@@ -219,12 +206,6 @@ jobs:
       max-parallel: 2
       matrix:
         python-version-minor: [7, 8, 9, 10]
-        include:
-<<<<<<< HEAD
-          - itk-python-git-tag: "v5.3rc04"
-=======
-          - itk-python-git-tag: "46dd4156e3adfa7cda8952cbec786fbd063ebc79"
->>>>>>> f70eb6d (ENH: Adding Python test for itk::PolyLineCell conversion)
 
     steps:
     - name: Get specific version of CMake, Ninja

--- a/include/itkPolyData.hxx
+++ b/include/itkPolyData.hxx
@@ -141,8 +141,8 @@ PolyData< TPixelType, TCellPixel >
   itkDebugMacro("setting Lines container to " << lines);
   if ( m_LinesContainer != lines )
     {
-    m_LinesContainer = lines;
-    this->Modified();
+      m_LinesContainer = lines;
+      this->Modified();
     }
 }
 

--- a/include/itkPolyDataToMeshFilter.hxx
+++ b/include/itkPolyDataToMeshFilter.hxx
@@ -22,6 +22,7 @@
 
 #include "itkVertexCell.h"
 #include "itkLineCell.h"
+#include "itkPolyLineCell.h"
 #include "itkMesh.h"
 #include "itkTriangleCell.h"
 #include "itkQuadrilateralCell.h"
@@ -205,9 +206,9 @@ PolyDataToMeshFilter<TInputPolyData>::GenerateData()
 
     while (inputCellItr != inputCellEnd)
     {
-#ifndef NDEBUG
+    #ifndef NDEBUG
       auto numPoints = inputCellItr.Value();
-#endif
+    #endif
       ++inputCellItr;
 
       // Verify vertex contains exactly one point ID
@@ -227,6 +228,8 @@ PolyDataToMeshFilter<TInputPolyData>::GenerateData()
 
   // Set line cells
   using LineCellType = itk::LineCell<CellType>;
+  using PolyLineCellType = itk::PolyLineCell<CellType>;
+
   if (inputPolyData->GetLines() != nullptr && !inputPolyData->GetLines()->empty())
   {
     const CellContainerType * inputLines = inputPolyData->GetLines();
@@ -238,12 +241,17 @@ PolyDataToMeshFilter<TInputPolyData>::GenerateData()
       auto numPoints = inputCellItr.Value();
       ++inputCellItr;
 
-      // Verify lines contain exactly two point IDs
-      itkAssertInDebugAndIgnoreInReleaseMacro(numPoints == LineCellType::NumberOfPoints);
-
-      // Create cell
       typename CellType::CellAutoPointer cell;
-      cell.TakeOwnership(new LineCellType);
+      // Use PolyLineCell Type
+      if (numPoints > LineCellType::NumberOfPoints)
+      {
+        cell.TakeOwnership(new PolyLineCellType);
+      }
+      // Use LineCell Type
+      else
+      {
+        cell.TakeOwnership(new LineCellType);
+      }
 
       for (unsigned int i = 0; i < numPoints; i++)
       {

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except ImportError:
 
 setup(
     name='itk-meshtopolydata',
-    version='0.8.4',
+    version='0.9.0',
     author='Insight Software Consortium',
     author_email='itk+community@discourse.itk.org',
     packages=['itk'],

--- a/test/itkMeshToPolyDataFilterTest.cxx
+++ b/test/itkMeshToPolyDataFilterTest.cxx
@@ -100,7 +100,6 @@ int itkMeshToPolyDataFilterTest( int argc, char * argv[] )
   ITK_TEST_EXPECT_TRUE( itk::Math::FloatAlmostEqual< float >( points->GetElement( 0 )[2], 0.0, 10, 1e-4 ) );
 
   ITK_TEST_EXPECT_EQUAL( polyData->GetVertices()->size(), 0 );
-
   ITK_TEST_EXPECT_EQUAL( polyData->GetLines()->size(), 0 );
 
   ITK_TEST_EXPECT_EQUAL( polyData->GetPolygons()->size(), 15593 );

--- a/test/itkPolyDataToMeshFilterTest.cxx
+++ b/test/itkPolyDataToMeshFilterTest.cxx
@@ -70,9 +70,10 @@ itkPolyDataToMeshFilterTest(int, char *[])
 
   // Verify line cells
   meshResult->GetCell(2, cellPtr);
-  ITK_TEST_EXPECT_EQUAL(cellPtr->GetNumberOfPoints(), 2);
-  ITK_TEST_EXPECT_EQUAL(cellPtr->GetPointIdsContainer()[0], 4);
-  ITK_TEST_EXPECT_EQUAL(cellPtr->GetPointIdsContainer()[1], 5);
+  ITK_TEST_EXPECT_EQUAL(cellPtr->GetNumberOfPoints(), 3);
+  ITK_TEST_EXPECT_EQUAL(cellPtr->GetPointIdsContainer()[0], 3);
+  ITK_TEST_EXPECT_EQUAL(cellPtr->GetPointIdsContainer()[1], 4);
+  ITK_TEST_EXPECT_EQUAL(cellPtr->GetPointIdsContainer()[2], 5);
   meshResult->GetCell(3, cellPtr);
   ITK_TEST_EXPECT_EQUAL(cellPtr->GetNumberOfPoints(), 2);
   ITK_TEST_EXPECT_EQUAL(cellPtr->GetPointIdsContainer()[0], 7);
@@ -142,12 +143,14 @@ MakePolyDataSample(itk::PolyData<TPixelType> * polyData)
   polyData->SetVertices(vertices);
 
   typename CellContainerType::Pointer lines = CellContainerType::New();
-  lines->InsertElement(0, 2);
-  lines->InsertElement(1, 4);
-  lines->InsertElement(2, 5);
-  lines->InsertElement(3, 2);
-  lines->InsertElement(4, 7);
-  lines->InsertElement(5, 8);
+  lines->InsertElement(0, 3);
+  lines->InsertElement(1, 3);
+  lines->InsertElement(2, 4);
+  lines->InsertElement(3, 5);
+
+  lines->InsertElement(4, 2);
+  lines->InsertElement(5, 7);
+  lines->InsertElement(6, 8);
   polyData->SetLines(lines);
 
   typename CellContainerType::Pointer strips = CellContainerType::New();

--- a/wrapping/test/CMakeLists.txt
+++ b/wrapping/test/CMakeLists.txt
@@ -2,6 +2,8 @@ itk_python_expression_add_test(NAME itkMeshToPolyDataFilterPythonTest
   EXPRESSION "filt = itk.MeshToPolyDataFilter.New()")
 itk_python_add_test(NAME itkMeshToPolyDataFilterPythonTest2
   COMMAND itkMeshToPolyDataFilterTest2.py)
+itk_python_add_test(NAME itkPolyLineCellTest
+  COMMAND itkPolyLineCellTest.py)
 itk_python_expression_add_test(NAME itkPolyDataPythonTest
   EXPRESSION "poly_data = itk.PolyData.New()")
 

--- a/wrapping/test/itkPolyLineCellTest.py
+++ b/wrapping/test/itkPolyLineCellTest.py
@@ -1,0 +1,44 @@
+import itk
+import numpy as np
+import os
+
+# Create a test mesh
+mesh_input = itk.Mesh[itk.D, 3].New()
+
+# Inserting 5 points in the Mesh
+points_arr  = np.array([0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 2, 1, 2, 3]).astype('float32')
+points_vc = itk.vector_container_from_array(points_arr.flatten())
+mesh_input.SetPoints(points_vc)
+
+# Inserting 3 cells comprising 1 PolyLine Cell and 2 Line Cells
+# LINES 3 10
+# 2 0 1
+# 3 0 2 5
+# 2 3 4
+before_cells_array = np.array([1, 2, 0, 1, 10, 3, 0, 2, 5, 1, 2, 3, 4]).astype('uint64')
+mesh_input.SetCellsArray(itk.vector_container_from_array(before_cells_array))
+
+# Convert Mesh to PolyData
+filter = itk.MeshToPolyDataFilter[type(mesh_input)].New(Input=mesh_input)
+filter.Update()
+poly_data = filter.GetOutput()
+assert(type(poly_data) == itk.PolyData[itk.D])
+lines = poly_data.GetLines()
+
+# Check the count of points in line cells of polydata
+assert(lines.Size() == 10)
+
+filter = itk.PolyDataToMeshFilter[type(poly_data)].New(Input=poly_data)
+filter.Update()
+mesh_output = filter.GetOutput()
+
+assert(mesh_output.GetNumberOfPoints() == mesh_input.GetNumberOfPoints())
+assert(mesh_output.GetNumberOfCells() == mesh_input.GetNumberOfCells())
+
+# Check if points are same
+for i in range(0, mesh_output.GetNumberOfPoints()):
+    assert(mesh_output.GetPoint(i) == mesh_input.GetPoint(i))
+
+# Check if cells are same
+after_cells_array = itk.array_from_vector_container(mesh_output.GetCellsArray())
+assert(np.array_equal(before_cells_array, after_cells_array))


### PR DESCRIPTION
This PR adds support for itk::PolyLineCell.

First, the itk::PolyLineCell needs to be merged for this build to succeed.

- Depending on the number of points in the Line we decide if **LineCell** of **PolyLineCell** needs to be created.
- Changed the **PolyDataToMeshFilterTest** to account for LineCell having more than 2 points.
- Visit for LineCell remains unchanged and a new Visit method with PolyLineCell is created.  Proposing to append the lines obtained from LineCell visitor and PolyLineCell visitor before calling `outputPolyData->SetLines(lines )`;
- Added **itkPolyLineCellTest.py** to test if PolylineCell conversion to polydata and back.

For Python build what tag should we use ?