### PR TITLE
COMP: ITK_DISALLOW_COPY_AND_ASSIGN -> ITK_DISALLOW_COPY_AND_MOVE

### DIFF
--- a/include/itkImageToPointSetFilter.h
+++ b/include/itkImageToPointSetFilter.h
@@ -38,7 +38,7 @@ template< typename TInputImage, typename TOutputMesh >
 class ITK_TEMPLATE_EXPORT ImageToPointSetFilter: public ImageToMeshFilter< TInputImage, TOutputMesh >
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ImageToPointSetFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(ImageToPointSetFilter);
 
   /** Standard class type alias. */
   using Self = ImageToPointSetFilter;

--- a/include/itkMeshToPolyDataFilter.h
+++ b/include/itkMeshToPolyDataFilter.h
@@ -58,7 +58,7 @@ template< typename TInputMesh >
 class MeshToPolyDataFilter: public ProcessObject
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(MeshToPolyDataFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(MeshToPolyDataFilter);
 
   static constexpr unsigned int PointDimension = TInputMesh::PointDimension;
 

--- a/include/itkPolyData.h
+++ b/include/itkPolyData.h
@@ -35,7 +35,7 @@ template< typename TPixel, typename TCellPixel = TPixel >
 class ITK_TEMPLATE_EXPORT PolyData: public DataObject
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(PolyData);
+  ITK_DISALLOW_COPY_AND_MOVE(PolyData);
 
   using Self = PolyData;
   using Superclass = DataObject;

--- a/include/itkPolyDataToMeshFilter.h
+++ b/include/itkPolyDataToMeshFilter.h
@@ -39,7 +39,7 @@ template <typename TInputPolyData>
 class PolyDataToMeshFilter : public ProcessObject
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(PolyDataToMeshFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(PolyDataToMeshFilter);
 
   /** Standard class typedefs. */
   using Self = PolyDataToMeshFilter<TInputPolyData>;


### PR DESCRIPTION
Addresses:
```log
Build started at 16:15...
1>------ Build started: Project: MeshToPolyDataTestDriver, Configuration: RelWithDebInfo x64 ------ 1>itkImageToPointSetFilterTest.cxx
1>itkMeshToPolyDataFilterTest.cxx
1>C:\Dev\ITK-git\Modules\Remote\MeshToPolyData\include\itkImageToPointSetFilter.h(41,3): error C2338: static_assert failed: 'Replace deprecated ITK_DISALLOW_COPY_AND_ASSIGN with modern ITK_DISALLOW_COPY_AND_MOVE' 1>(compiling source file '../../../../../ITK-git/Modules/Remote/MeshToPolyData/test/itkImageToPointSetFilterTest.cxx')
1>    C:\Dev\ITK-git\Modules\Remote\MeshToPolyData\include\itkImageToPointSetFilter.h(41,3):
1>    the template instantiation context (the oldest one first) is
1>        C:\Dev\ITK-git\Modules\Remote\MeshToPolyData\test\itkImageToPointSetFilterTest.cxx(44,15):
1>        see reference to class template instantiation 'itk::ImageToPointSetFilter<itkImageToPointSetFilterTest::InputImageType,itkImageToPointSetFilterTest::OutputMeshType>' being compiled
1>C:\Dev\ITK-git\Modules\Remote\MeshToPolyData\include\itkMeshToPolyDataFilter.h(61,3): error C2338: static_assert failed: 'Replace deprecated ITK_DISALLOW_COPY_AND_ASSIGN with modern ITK_DISALLOW_COPY_AND_MOVE'
1>(compiling source file '../../../../../ITK-git/Modules/Remote/MeshToPolyData/test/itkMeshToPolyDataFilterTest.cxx')
1>    C:\Dev\ITK-git\Modules\Remote\MeshToPolyData\include\itkMeshToPolyDataFilter.h(61,3):
1>    the template instantiation context (the oldest one first) is
1>        C:\Dev\ITK-git\Modules\Remote\MeshToPolyData\test\itkMeshToPolyDataFilterTest.cxx(81,15):
1>        see reference to class template instantiation 'itk::MeshToPolyDataFilter<itkMeshToPolyDataFilterTest::MeshType>' being compiled
1>C:\Dev\ITK-git\Modules\Remote\MeshToPolyData\include\itkPolyData.h(38,3): error C2338: static_assert failed: 'Replace deprecated ITK_DISALLOW_COPY_AND_ASSIGN with modern ITK_DISALLOW_COPY_AND_MOVE'
1>(compiling source file '../../../../../ITK-git/Modules/Remote/MeshToPolyData/test/itkMeshToPolyDataFilterTest.cxx')
1>    C:\Dev\ITK-git\Modules\Remote\MeshToPolyData\include\itkPolyData.h(38,3):
1>    the template instantiation context (the oldest one first) is
1>        C:\Dev\ITK-git\Modules\Remote\MeshToPolyData\test\itkMeshToPolyDataFilterTest.cxx(93,17):
1>        see reference to class template instantiation 'itk::PolyData<float,TPixel>' being compiled
1>        with
1>        [
1>            TPixel=float
1>        ]
1>C:\Dev\ITK-git\Modules\Remote\MeshToPolyData\include\itkPolyDataToMeshFilter.h(42,3): error C2338: static_assert failed: 'Replace deprecated ITK_DISALLOW_COPY_AND_ASSIGN with modern ITK_DISALLOW_COPY_AND_MOVE'
1>(compiling source file '../../../../../ITK-git/Modules/Remote/MeshToPolyData/test/itkMeshToPolyDataFilterTest.cxx')
1>    C:\Dev\ITK-git\Modules\Remote\MeshToPolyData\include\itkPolyDataToMeshFilter.h(42,3):
1>    the template instantiation context (the oldest one first) is
1>        C:\Dev\ITK-git\Modules\Remote\MeshToPolyData\test\itkMeshToPolyDataFilterTest.cxx(115,57):
1>        see reference to class template instantiation 'itk::PolyDataToMeshFilter<itkMeshToPolyDataFilterTest::PolyDataType>' being compiled
1>itkPolyDataTest.cxx
1>C:\Dev\ITK-git\Modules\Remote\MeshToPolyData\include\itkPolyData.h(38,3): error C2338: static_assert failed: 'Replace deprecated ITK_DISALLOW_COPY_AND_ASSIGN with modern ITK_DISALLOW_COPY_AND_MOVE'
1>(compiling source file '../../../../../ITK-git/Modules/Remote/MeshToPolyData/test/itkPolyDataTest.cxx')
1>    C:\Dev\ITK-git\Modules\Remote\MeshToPolyData\include\itkPolyData.h(38,3):
1>    the template instantiation context (the oldest one first) is
1>        C:\Dev\ITK-git\Modules\Remote\MeshToPolyData\test\itkPolyDataTest.cxx(27,17):
1>        see reference to class template instantiation 'itk::PolyData<itkPolyDataTest::PixelType,TPixel>' being compiled
1>        with
1>        [
1>            TPixel=itkPolyDataTest::PixelType
1>        ]
1>itkPolyDataToMeshFilterTest.cxx
1>C:\Dev\ITK-git\Modules\Remote\MeshToPolyData\include\itkPolyData.h(38,3): error C2338: static_assert failed: 'Replace deprecated ITK_DISALLOW_COPY_AND_ASSIGN with modern ITK_DISALLOW_COPY_AND_MOVE'
1>(compiling source file '../../../../../ITK-git/Modules/Remote/MeshToPolyData/test/itkPolyDataToMeshFilterTest.cxx')
1>    C:\Dev\ITK-git\Modules\Remote\MeshToPolyData\include\itkPolyData.h(38,3):
1>    the template instantiation context (the oldest one first) is
1>        C:\Dev\ITK-git\Modules\Remote\MeshToPolyData\test\itkPolyDataToMeshFilterTest.cxx(35,17):
1>        see reference to class template instantiation 'itk::PolyData<itkPolyDataToMeshFilterTest::PixelType,TPixel>' being compiled
1>        with
1>        [
1>            TPixel=itkPolyDataToMeshFilterTest::PixelType
1>        ]
1>C:\Dev\ITK-git\Modules\Remote\MeshToPolyData\include\itkPolyDataToMeshFilter.h(42,3): error C2338: static_assert failed: 'Replace deprecated ITK_DISALLOW_COPY_AND_ASSIGN with modern ITK_DISALLOW_COPY_AND_MOVE'
1>(compiling source file '../../../../../ITK-git/Modules/Remote/MeshToPolyData/test/itkPolyDataToMeshFilterTest.cxx')
1>    C:\Dev\ITK-git\Modules\Remote\MeshToPolyData\include\itkPolyDataToMeshFilter.h(42,3):
1>    the template instantiation context (the oldest one first) is
1>        C:\Dev\ITK-git\Modules\Remote\MeshToPolyData\test\itkPolyDataToMeshFilterTest.cxx(40,15):
1>        see reference to class template instantiation 'itk::PolyDataToMeshFilter<itkPolyDataToMeshFilterTest::PolyDataType>' being compiled
1>Generating Code...
1>Done building project "MeshToPolyDataTestDriver.vcxproj" -- FAILED.
========== Build: 0 succeeded, 1 failed, 0 up-to-date, 0 skipped ==========
========== Build completed at 16:15 and took 06.867 seconds ==========
```