### PR TITLE
vlv float32

### DIFF
--- a/wasm/mesh-to-poly-data.cxx
+++ b/wasm/mesh-to-poly-data.cxx
@@ -68,7 +68,9 @@ int main (int argc, char * argv[])
    float,
    double,
    itk::Vector<uint8_t, 3>,
-   itk::Vector<float, 3>
+   itk::Vector<float, 3>,
+   itk::VariableLengthVector<uint8_t>,
+   itk::VariableLengthVector<float>
    >
   ::Dimensions<2U,3U>("mesh", pipeline);
 }

--- a/wasm/typescript/package.json
+++ b/wasm/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itk-wasm/mesh-to-poly-data",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Convert an ITK Mesh to a simple data structure compatible with vtkPolyData.",
   "type": "module",
   "module": "./dist/index.js",


### PR DESCRIPTION
- BUG: Support Variable-Length-Vector in mesh-to-polydata
- ENH: Bump wasm package version to 1.1.1
