### PR TITLE
STYLE: Add itkVirtualGetNameOfClassMacro + itkOverrideGetNameOfClassMacro

### DIFF
--- a/include/itkImageToPointSetFilter.h
+++ b/include/itkImageToPointSetFilter.h
@@ -50,7 +50,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ImageToPointSetFilter, ImageToMeshFilter);
+  itkOverrideGetNameOfClassMacro(ImageToPointSetFilter);
 
   /** Some convenient type alias. */
   using InputImageType = TInputImage;

--- a/include/itkImageToPointSetFilter.h
+++ b/include/itkImageToPointSetFilter.h
@@ -71,10 +71,10 @@ public:
   using PointDataContainerIterator = typename PointDataContainer::Iterator;
 
   /** The dimension of the output mesh. */
-  itkStaticConstMacro(PointDimension, unsigned int, TOutputMesh::PointDimension);
+  static constexpr unsigned int PointDimension = TOutputMesh::PointDimension;
 
   /** ImageDimension constant */
-  itkStaticConstMacro(ImageDimension, unsigned int, TInputImage::ImageDimension);
+  static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;
 
 protected:
   ImageToPointSetFilter() {}

--- a/include/itkMeshToPolyDataFilter.h
+++ b/include/itkMeshToPolyDataFilter.h
@@ -73,7 +73,7 @@ public:
   using PolyDataType = PolyData< typename InputMeshType::PixelType >;
 
   /** Run-time type information. */
-  itkTypeMacro( MeshToPolyDataFilter, ProcessObject );
+  itkOverrideGetNameOfClassMacro( MeshToPolyDataFilter);
 
   /** Standard New macro. */
   itkNewMacro( Self );

--- a/include/itkPolyData.h
+++ b/include/itkPolyData.h
@@ -49,7 +49,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(PolyData, DataObject);
+  itkOverrideGetNameOfClassMacro(PolyData);
 
   /** Type of PointData or CellData */
   using PixelType = TPixel;

--- a/include/itkPolyDataToMeshFilter.h
+++ b/include/itkPolyDataToMeshFilter.h
@@ -51,7 +51,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information. */
-  itkTypeMacro(PolyDataToMeshFilter, ProcessObject);
+  itkOverrideGetNameOfClassMacro(PolyDataToMeshFilter);
 
   static constexpr unsigned int PointDimension = TInputPolyData::PointDimension;
 


### PR DESCRIPTION
Added two new macro's, intended to replace the old 'itkTypeMacro' and
'itkTypeMacroNoParent'.

The main aim is to be clearer about what those macro's do: add a virtual
'GetNameOfClass()' member function and override it. Unlike 'itkTypeMacro',
'itkOverrideGetNameOfClassMacro' does not have a 'superclass' parameter, as it
was not used anyway.

Note that originally 'itkTypeMacro' did not use its 'superclass' parameter
either, looking at commit 699b66cb04d410e555656828e8892107add38ccb, Will
Schroeder, June 27, 2001:
https://github.com/InsightSoftwareConsortium/ITK/blob/699b66cb04d410e555656828e8892107add38ccb/Code/Common/itkMacro.h#L331-L337
