### PR TITLE
COMP: Bump to minimum CMake 3.16.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2)
+cmake_minimum_required(VERSION 3.16.3)
 project(MeshToPolyData)
 
 if(NOT ITK_SOURCE_DIR)


### PR DESCRIPTION
Bump to minimum CMake 3.16.3: use same `cmake_minimum_required` values as ITK.

Bumped in ITK in commit
https://github.com/InsightSoftwareConsortium/ITK/commit/b01b3258bddaedc365c1fcbffd3332b82d7f539f

Fixes:
```
-- cmake_minimum_required of 3.10.2 is not enough.
CMake Warning at D:/a/ITKMeshToPolyData/ITK/CMake/ITKModuleExternal.cmake:15 (message):
  cmake_minimum_required must be at least 3.16.3
Call Stack (most recent call first):
  CMakeLists.txt:7 (include)
```

raised for example in:
https://open.cdash.org/builds/10259385